### PR TITLE
Fixed a bug in Ransac proposer

### DIFF
--- a/LocalExpansionStereo/Proposer.h
+++ b/LocalExpansionStereo/Proposer.h
@@ -184,7 +184,7 @@ protected:
 		cv::Mat inls = cv::Mat_<uchar>(len, 1, (uchar)0);
 		int no_i_c = 0;
 		cv::Mat N = cv::Mat_<float>(3, 1);
-		cv::Mat result;
+		cv::Mat result = cv::Mat_<float>(3, 1);
 
 		cv::Mat ranpts = cv::Mat_<float>::zeros(3, 3);
 		cv::Mat ranpts_ = cv::Mat_<cv::Vec3f>(ranpts);

--- a/LocalExpansionStereo/Proposer.h
+++ b/LocalExpansionStereo/Proposer.h
@@ -183,8 +183,8 @@ protected:
 		cv::Mat div = cv::Mat_<float>::zeros(3, 1);
 		cv::Mat inls = cv::Mat_<uchar>(len, 1, (uchar)0);
 		int no_i_c = 0;
-		cv::Mat N = cv::Mat_<float>(3, 1);
-		cv::Mat result = cv::Mat_<float>(3, 1);
+		cv::Mat N = cv::Mat_<float>::zeros(3, 1);
+		cv::Mat result = cv::Mat_<float>::zeros(3, 1);
 
 		cv::Mat ranpts = cv::Mat_<float>::zeros(3, 3);
 		cv::Mat ranpts_ = cv::Mat_<cv::Vec3f>(ranpts);


### PR DESCRIPTION
The "result" variable in RANSACPlane() was not initialized, so the application would crash sporadically whenever the logic flow didn't touch the if statement, where the variable was finally getting it's value.